### PR TITLE
Mesh Viewer: remove duplicated zoom speed label

### DIFF
--- a/gui/mesh_tab.py
+++ b/gui/mesh_tab.py
@@ -140,9 +140,6 @@ def create_mesh_viewer_tab(self):
 
     # Zoom Speed Slider
     zoom_speed_label = QLabel(f"Camera Zoom Speed Control: {default_zoom_speed:.2f}")
-
-    # Zoom Speed Slider
-    zoom_speed_label = QLabel("Camera Zoom Speed Control:")
     zoom_speed_label.setFixedHeight(15)
     right_side.addWidget(zoom_speed_label)
 


### PR DESCRIPTION
This also fixes the label has no initial zoom speed