### PR TITLE
Remove size limit of decrypt key

### DIFF
--- a/gui/windows/config_manager/edit_config_dialog.py
+++ b/gui/windows/config_manager/edit_config_dialog.py
@@ -46,8 +46,8 @@ class EditConfigDialog(QDialog):
 
         # Decryption key field
         self.key_edit = QSpinBox()
-        self.key_edit.setMinimum(-999999)
-        self.key_edit.setMaximum(999999)
+        self.key_edit.setMinimum(-2147483648)  # int32 min
+        self.key_edit.setMaximum(2147483647)   # int32 max
         if config.read_options is None or config.read_options.decryption_key is None:
             self.key_edit.setValue(0)
         else:

--- a/gui/windows/config_manager/new_config_dialog.py
+++ b/gui/windows/config_manager/new_config_dialog.py
@@ -38,8 +38,8 @@ class NewConfigDialog(QDialog):
 
         # Decryption key field
         self.key_edit = QSpinBox()
-        self.key_edit.setMinimum(-999999)
-        self.key_edit.setMaximum(999999)
+        self.key_edit.setMinimum(-2147483648)  # int32 min
+        self.key_edit.setMaximum(2147483647)   # int32 max
         self.key_edit.setValue(0)  # Default value
         self.form_layout.addRow("Decryption Key (Use 0 for no key):", self.key_edit)
 


### PR DESCRIPTION
in config panel, the "Decryption Key" only allow a value less than int(100_0000).

But some reports shows a xor key for simple crypt is 3xx_xxxx, which is larger than 100_0000

also i am used my own decrypt tool to verified this decrypt key is correct 
