### PR TITLE
Add IDX/WPK support and related archive handling improvements

### DIFF
--- a/core/formats/__init__.py
+++ b/core/formats/__init__.py
@@ -1,0 +1,12 @@
+"""Format processors for post-unpack NeoX resource decoding."""
+
+from .base import FormatDecodeResult, FormatProcessor
+from .registry import load_external_processors, process_entry_with_processors, try_process_data
+
+__all__ = [
+    "FormatDecodeResult",
+    "FormatProcessor",
+    "load_external_processors",
+    "process_entry_with_processors",
+    "try_process_data",
+]

--- a/core/formats/base.py
+++ b/core/formats/base.py
@@ -1,0 +1,35 @@
+"""Base types for special-format processors."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(slots=True)
+class FormatDecodeResult:
+    """Decoded result produced by a format processor."""
+
+    data: bytes | str
+    extension: str | None = None
+    is_text: bool = False
+    processor_name: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def as_bytes(self) -> bytes:
+        if isinstance(self.data, bytes):
+            return self.data
+        return self.data.encode("utf-8")
+
+
+class FormatProcessor:
+    """Base class for special-format processors."""
+
+    name = "processor"
+    priority = 100
+
+    def probe(self, data: bytes, entry) -> bool:
+        raise NotImplementedError
+
+    def decode(self, data: bytes, entry) -> FormatDecodeResult | None:
+        raise NotImplementedError

--- a/core/formats/bxml.py
+++ b/core/formats/bxml.py
@@ -1,0 +1,190 @@
+"""NeoX BXML decoder."""
+# Source / attribution:
+# Original script provided by Discord user JohnSmith.
+# Modified and integrated for this project.
+
+from __future__ import annotations
+
+import struct
+import xml.etree.ElementTree as ET
+from io import BytesIO
+from xml.dom import minidom
+
+from .base import FormatDecodeResult, FormatProcessor
+
+BXML_MAGIC = b"\xC1\x59\x41\x0D"
+
+
+def _read_leb128(buf: BytesIO) -> int:
+    result = 0
+    shift = 0
+    while True:
+        byte = buf.read(1)
+        if not byte:
+            break
+        value = byte[0]
+        result |= (value & 0x7F) << shift
+        if (value & 0x80) == 0:
+            break
+        shift += 7
+    return result
+
+
+def _read_null_terminated_utf8(buf: BytesIO) -> str:
+    chars = bytearray()
+    while True:
+        b = buf.read(1)
+        if b == b"\x00" or not b:
+            break
+        chars.extend(b)
+    return chars.decode("utf-8", errors="ignore")
+
+
+def _read_string_pool(buf: BytesIO) -> list[str]:
+    count = _read_leb128(buf)
+    strings: list[str] = []
+    for _ in range(count):
+        strings.append(_read_null_terminated_utf8(buf))
+    return strings
+
+
+def _read_bxml_value(buf: BytesIO, type_tag: int) -> str:
+    if type_tag == 0:
+        return ""
+    if type_tag == 1:
+        return _read_null_terminated_utf8(buf)
+    if type_tag in (2, 4):
+        data = buf.read(4)
+        if len(data) != 4:
+            return ""
+        return str(struct.unpack("<i", data)[0])
+    if type_tag == 5:
+        data = buf.read(4)
+        if len(data) != 4:
+            return ""
+        return str(round(struct.unpack("<f", data)[0], 4))
+    if type_tag == 3:
+        data = buf.read(1)
+        if len(data) != 1:
+            return ""
+        return str(struct.unpack("<B", data)[0])
+    if type_tag == 6:
+        data = buf.read(4)
+        if len(data) != 4:
+            return ""
+        length = struct.unpack("<I", data)[0]
+        float_data = buf.read(length * 4)
+        if len(float_data) != length * 4:
+            return float_data.hex()
+        try:
+            floats = struct.unpack("<" + "f" * length, float_data)
+            return "[" + ", ".join(f"{round(v, 4)}" for v in floats) + "]"
+        except Exception:
+            return float_data.hex()
+    if type_tag in (7, 8):
+        data = buf.read(8)
+        if len(data) != 8:
+            return ""
+        return str(struct.unpack("<q", data)[0])
+    return ""
+
+
+def parse_bxml_bytes(data: bytes) -> str:
+    buf = BytesIO(data)
+    magic = buf.read(4)
+    if magic != BXML_MAGIC:
+        raise ValueError("Not a valid NeoX BXML payload.")
+
+    total_size_raw = buf.read(8)
+    if len(total_size_raw) != 8:
+        raise ValueError("Truncated BXML header.")
+    _total_size = struct.unpack("<Q", total_size_raw)[0]
+    payload_start = buf.tell()
+
+    tag_names = _read_string_pool(buf)
+    attr_names = _read_string_pool(buf)
+
+    attr_data_offset_raw = buf.read(8)
+    if len(attr_data_offset_raw) != 8:
+        raise ValueError("Missing BXML attribute data offset.")
+    attr_data_offset = struct.unpack("<Q", attr_data_offset_raw)[0]
+
+    node_count = _read_leb128(buf)
+    nodes_info: list[dict[str, object]] = []
+    for i in range(node_count):
+        tag_idx = _read_leb128(buf)
+        child_count = _read_leb128(buf)
+        tag_name = tag_names[tag_idx] if 0 <= tag_idx < len(tag_names) else f"node_{i}"
+        nodes_info.append({"tag": tag_name, "child_count": child_count})
+
+    buf.seek(payload_start + attr_data_offset)
+
+    for i in range(node_count):
+        attr_count = _read_leb128(buf)
+        attrs: dict[str, str] = {}
+        for j in range(attr_count):
+            attr_idx = _read_leb128(buf)
+            type_tag_raw = buf.read(1)
+            if not type_tag_raw:
+                raise ValueError("Unexpected end of file while reading BXML attributes.")
+            type_tag = type_tag_raw[0]
+            key = attr_names[attr_idx] if 0 <= attr_idx < len(attr_names) else f"attr_{j}"
+            attrs[key] = _read_bxml_value(buf, type_tag)
+        nodes_info[i]["attrs"] = attrs
+
+        node_type_tag_raw = buf.read(1)
+        if not node_type_tag_raw:
+            raise ValueError("Unexpected end of file while reading BXML node value.")
+        node_type_tag = node_type_tag_raw[0]
+        nodes_info[i]["value"] = _read_bxml_value(buf, node_type_tag)
+
+    current_node_idx = 0
+
+    def build_xml_tree():
+        nonlocal current_node_idx
+        if current_node_idx >= len(nodes_info):
+            return None
+
+        info = nodes_info[current_node_idx]
+        current_node_idx += 1
+
+        elem = ET.Element(str(info["tag"]), info.get("attrs", {}))
+        value = info.get("value")
+        if value:
+            elem.text = str(value)
+
+        for _ in range(int(info.get("child_count", 0))):
+            child = build_xml_tree()
+            if child is not None:
+                elem.append(child)
+        return elem
+
+    root = build_xml_tree()
+    if root is None:
+        raise ValueError("BXML contains no nodes.")
+
+    xml_bytes = ET.tostring(root, encoding="utf-8")
+    pretty_xml = minidom.parseString(xml_bytes).toprettyxml(indent="  ")
+    lines = pretty_xml.split("\n")
+    if lines and lines[0].startswith("<?xml"):
+        pretty_xml = "\n".join(lines[1:]).lstrip("\n")
+    return pretty_xml
+
+
+
+class NeoXBXMLProcessor(FormatProcessor):
+    name = "BXML"
+    priority = 10
+
+    def probe(self, data: bytes, entry) -> bool:
+        return data[:4] == BXML_MAGIC
+
+    def decode(self, data: bytes, entry) -> FormatDecodeResult | None:
+        xml_text = parse_bxml_bytes(data)
+        return FormatDecodeResult(
+            data=xml_text,
+            extension="xml",
+            is_text=True,
+            processor_name=self.name,
+            metadata={"input_extension": getattr(entry, "extension", "")},
+        )

--- a/core/formats/registry.py
+++ b/core/formats/registry.py
@@ -1,0 +1,173 @@
+"""Registry for built-in and external format processors."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+
+from core.logger import get_logger
+
+from .base import FormatDecodeResult, FormatProcessor
+from .bxml import NeoXBXMLProcessor
+
+
+class FunctionFormatProcessor(FormatProcessor):
+    def __init__(self, name: str, probe_fn, decode_fn, priority: int = 100):
+        self.name = name
+        self.priority = priority
+        self._probe = probe_fn
+        self._decode = decode_fn
+
+    def probe(self, data: bytes, entry) -> bool:
+        return bool(self._probe(data, entry))
+
+    def decode(self, data: bytes, entry) -> FormatDecodeResult | None:
+        result = self._decode(data, entry)
+        if result is None:
+            return None
+        if isinstance(result, FormatDecodeResult):
+            if not result.processor_name:
+                result.processor_name = self.name
+            return result
+        if isinstance(result, dict):
+            return FormatDecodeResult(
+                data=result.get("data", b""),
+                extension=result.get("extension"),
+                is_text=bool(result.get("is_text", False)),
+                processor_name=result.get("processor_name", self.name),
+                metadata=dict(result.get("metadata", {})),
+            )
+        raise TypeError(f"Unsupported decode result type from plugin {self.name}: {type(result)!r}")
+
+
+_BUILTIN_PROCESSORS: list[FormatProcessor] = [NeoXBXMLProcessor()]
+_EXTERNAL_PROCESSORS: list[FormatProcessor] | None = None
+
+
+def _project_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _candidate_plugin_dirs() -> list[Path]:
+    project_root = _project_root()
+    dirs = [project_root / "plugins" / "format_processors"]
+    env_dir = os.environ.get("NEOXTRACTOR_PLUGIN_DIR")
+    if env_dir:
+        dirs.insert(0, Path(env_dir))
+    exe_dir = Path(sys.argv[0]).resolve().parent / "plugins" / "format_processors"
+    if exe_dir not in dirs:
+        dirs.append(exe_dir)
+    unique_dirs: list[Path] = []
+    seen: set[str] = set()
+    for directory in dirs:
+        key = str(directory)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique_dirs.append(directory)
+    return unique_dirs
+
+
+def _load_module_from_path(path: Path) -> ModuleType | None:
+    module_name = f"neoxtractor_plugin_{path.stem}_{abs(hash(str(path)))}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        return None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _module_to_processor(module: ModuleType, default_name: str) -> FormatProcessor | None:
+    if hasattr(module, "PROCESSOR"):
+        processor = getattr(module, "PROCESSOR")
+        if isinstance(processor, FormatProcessor):
+            return processor
+    if hasattr(module, "get_processor"):
+        processor = module.get_processor()
+        if isinstance(processor, FormatProcessor):
+            return processor
+    if hasattr(module, "probe") and hasattr(module, "decode"):
+        return FunctionFormatProcessor(
+            name=getattr(module, "NAME", default_name),
+            probe_fn=getattr(module, "probe"),
+            decode_fn=getattr(module, "decode"),
+            priority=int(getattr(module, "PRIORITY", 100)),
+        )
+    return None
+
+
+def load_external_processors(force_reload: bool = False) -> list[FormatProcessor]:
+    global _EXTERNAL_PROCESSORS
+    if _EXTERNAL_PROCESSORS is not None and not force_reload:
+        return _EXTERNAL_PROCESSORS
+
+    processors: list[FormatProcessor] = []
+    for directory in _candidate_plugin_dirs():
+        if not directory.exists() or not directory.is_dir():
+            continue
+        for path in sorted(directory.glob("*.py")):
+            if path.name.startswith("_"):
+                continue
+            try:
+                module = _load_module_from_path(path)
+                if module is None:
+                    continue
+                processor = _module_to_processor(module, default_name=path.stem)
+                if processor is None:
+                    get_logger().warning("Skipping plugin without valid processor API: %s", path)
+                    continue
+                processors.append(processor)
+                get_logger().info("Loaded external format processor: %s (%s)", processor.name, path)
+            except Exception as exc:
+                get_logger().exception("Failed to load format processor plugin %s: %s", path, exc)
+    _EXTERNAL_PROCESSORS = sorted(processors, key=lambda p: getattr(p, "priority", 100))
+    return _EXTERNAL_PROCESSORS
+
+
+def get_all_processors() -> list[FormatProcessor]:
+    return sorted([*_BUILTIN_PROCESSORS, *load_external_processors()], key=lambda p: getattr(p, "priority", 100))
+
+
+def try_process_data(data: bytes, entry) -> FormatDecodeResult | None:
+    for processor in get_all_processors():
+        try:
+            if not processor.probe(data, entry):
+                continue
+            result = processor.decode(data, entry)
+            if result is None:
+                continue
+            if not result.processor_name:
+                result.processor_name = processor.name
+            return result
+        except Exception as exc:
+            get_logger().exception(
+                "Format processor %s failed on %s: %s",
+                getattr(processor, "name", processor.__class__.__name__),
+                getattr(entry, "filename", "<unknown>"),
+                exc,
+            )
+    return None
+
+
+def process_entry_with_processors(entry) -> bool:
+    from core.npk.class_types import NPKEntryDataFlags
+
+    result = try_process_data(entry.data, entry)
+    if result is None:
+        return False
+
+    original_data = entry.data
+    entry.source_data = original_data
+    entry.data = result.as_bytes()
+    entry.processed_by = result.processor_name
+    entry.has_decoded_view = True
+    entry.format_metadata = dict(result.metadata)
+    if result.extension:
+        entry.extension = result.extension
+    if result.is_text:
+        entry.data_flags |= NPKEntryDataFlags.TEXT
+    return True

--- a/core/images.py
+++ b/core/images.py
@@ -11,9 +11,54 @@ from bitstring import ConstBitStream
 
 from core.binary_readers import read_uintle32, read_uintle64
 
-#tga, ico, tiff, dds
+
+def _dds_dxgi_fallback(data: bytes):
+    """Fallback DDS decoder for simple DX10 BGRA/BGRX formats unsupported by Pillow."""
+    if len(data) < 148 or data[:4] != b"DDS ":
+        raise ValueError("Not a DDS file")
+
+    header_size = int.from_bytes(data[4:8], "little")
+    if header_size != 124:
+        raise ValueError(f"Unsupported DDS header size: {header_size}")
+
+    height = int.from_bytes(data[12:16], "little")
+    width = int.from_bytes(data[16:20], "little")
+    fourcc = data[84:88]
+
+    if fourcc != b"DX10":
+        raise NotImplementedError("DDS fallback only handles DX10 DDS files")
+
+    dxgi_format = int.from_bytes(data[128:132], "little")
+    pixel_data = data[148:]
+
+    if dxgi_format in (87, 91):  # B8G8R8A8_UNORM / _SRGB
+        expected = width * height * 4
+        if len(pixel_data) < expected:
+            raise ValueError(
+                f"DDS pixel data truncated for DXGI {dxgi_format}: expected {expected}, got {len(pixel_data)}"
+            )
+        return Image.frombytes("RGBA", (width, height), pixel_data[:expected], "raw", "BGRA")
+
+    if dxgi_format in (88, 93):  # B8G8R8X8_UNORM / _SRGB
+        expected = width * height * 4
+        if len(pixel_data) < expected:
+            raise ValueError(
+                f"DDS pixel data truncated for DXGI {dxgi_format}: expected {expected}, got {len(pixel_data)}"
+            )
+        image = Image.frombytes("RGBX", (width, height), pixel_data[:expected], "raw", "BGRX")
+        return image.convert("RGBA")
+
+    raise NotImplementedError(f"Unsupported DDS DXGI fallback format {dxgi_format}")
+
+
+#tga, ico, tiff, dds, psd
 def _pillow_image_conversion(data, fmt):
-    return Image.open(io.BytesIO(data), "r", (fmt.upper(), "PNG"))
+    try:
+        return Image.open(io.BytesIO(data), "r", (fmt.upper(), "PNG"))
+    except NotImplementedError:
+        if fmt.lower() == "dds":
+            return _dds_dxgi_fallback(data)
+        raise
 
 def image_to_png_data(img: Image.Image | ImageFile.ImageFile) -> bytes:
     """Convert an image to PNG data."""
@@ -25,11 +70,22 @@ def _get_pitch(width):
     return max(1, ((width+3)//4) ) * 16
 
 def _get_astc_file_size(width, height, block_x, block_y):
-    return math.ceil(width/block_y) * math.ceil(height/block_x) * 16
+    return math.ceil(width / block_x) * math.ceil(height / block_y) * 16
+
+
+def _validate_astc_payload(data: bytes, width: int, height: int, block_x: int, block_y: int):
+    expected = _get_astc_file_size(width, height, block_x, block_y)
+    if len(data) < expected:
+        raise ValueError(
+            f"ASTC payload truncated for {block_x}x{block_y}: expected {expected}, got {len(data)}"
+        )
+    return data[:expected]
+
 
 def _decode_correct_format(fmt, data, width, height, block_x = 4, block_y = 4):
     match fmt:
         case "ASTC":
+            data = _validate_astc_payload(data, width, height, block_x, block_y)
             data = texture2ddecoder.decode_astc(data, width, height, block_x, block_y)
         case "BC1":
             data = texture2ddecoder.decode_bc1(data, width, height)
@@ -96,7 +152,7 @@ def pvr_convert(data: bytes):
         case 30:
             return _decode_correct_format("ASTC", image_data, width, height, 6, 5)
         case 31:
-            return _decode_correct_format("ASTC", image_data, width, height, 6, 5)
+            return _decode_correct_format("ASTC", image_data, width, height, 6, 6)
         case 32:
             return _decode_correct_format("ASTC", image_data, width, height, 8, 5)
         case 33:
@@ -152,7 +208,7 @@ def ktx_convert(data: bytes):
         case 0x93B3:
             return _decode_correct_format("ASTC", image_data, width, height, 6, 5)
         case 0x93B4:
-            return _decode_correct_format("ASTC", image_data, width, height, 6, 5)
+            return _decode_correct_format("ASTC", image_data, width, height, 6, 6)
         case 0x93B5:
             return _decode_correct_format("ASTC", image_data, width, height, 8, 5)
         case 0x93B6:
@@ -182,11 +238,14 @@ def astc_convert(data: bytes):
 
 def convert_image(data, extension):
     """Identify and convert image data to Image."""
-    if extension == "dds":
-        return _pillow_image_conversion(data, extension)
+    if extension in ("dds", "psd"):
+        image = _pillow_image_conversion(data, extension)
+        if extension == "psd":
+            image = image.convert("RGBA")
+        return image
     if extension == "pvr":
         return pvr_convert(data)
-    if extension in ["ktx", "ktx_low"]:
+    if extension in ("ktx", "ktx_low"):
         return ktx_convert(data)
     if extension == "astc":
         return astc_convert(data)

--- a/core/npk/class_types.py
+++ b/core/npk/class_types.py
@@ -59,6 +59,11 @@ class NPKEntry(NPKIndex, IFile):
         self._data: bytes = b""
         self._extension: str | None = None
         self.category: NPKEntryFileCategories = NPKEntryFileCategories.OTHER
+        self.source_data: bytes | None = None
+        self.source_extension: str = ""
+        self.processed_by: str | None = None
+        self.has_decoded_view: bool = False
+        self.format_metadata: dict = {}
 
     @property
     def is_compressed(self) -> bool:

--- a/core/npk/class_types.py
+++ b/core/npk/class_types.py
@@ -75,11 +75,37 @@ class NPKEntry(NPKIndex, IFile):
         """Check if the entry is encrypted."""
         return self.encrypt_flag != 0
 
-    def save_to_file(self, path: str) -> None:
+    def save_to_file(self, path: str, decoded: bool = True) -> None:
         """Save the file data to the specified path."""
-        os.makedirs(os.path.dirname(path), exist_ok=True)
+        dir_name = os.path.dirname(path)
+        if dir_name:
+            os.makedirs(dir_name, exist_ok=True)
         with open(path, 'wb') as f:
-            f.write(self.data)
+            f.write(self.get_export_data(decoded=decoded))
+
+    def get_export_data(self, decoded: bool = True) -> bytes:
+        """Return decoded data by default, or the original source bytes when available."""
+        if decoded or not self.has_decoded_view or self.source_data is None:
+            return self.data
+        return self.source_data
+
+    def get_export_filename(self, decoded: bool = True) -> str:
+        """Return a filename that matches the chosen export payload."""
+        filename = self.filename
+        base_name, existing_ext = os.path.splitext(filename)
+
+        if decoded:
+            if self.has_decoded_view and self.extension:
+                return f"{base_name}.{self.extension}" if existing_ext else f"{filename}.{self.extension}"
+            return filename
+
+        if not self.has_decoded_view:
+            return filename
+
+        source_ext = self.source_extension or self.extension
+        if existing_ext:
+            return f"{base_name}.{source_ext}" if source_ext else filename
+        return f"{filename}.{source_ext}" if source_ext else filename
 
     def __repr__(self) -> str:
         return (

--- a/core/npk/decompression.py
+++ b/core/npk/decompression.py
@@ -55,6 +55,85 @@ def decompress_entry(entry: NPKEntry):
     # No matched compression.
     return entry.data
 
+def strip_none_wrapper(data: bytes) -> bytes:
+    """Strip a simple NONE wrapper header if present."""
+    if data[:4] == b"NONE":
+        return data[4:]
+    return data
+
+
+def check_lz4_like(data: bytes) -> bool:
+    """Check for the custom LZ4-like stream seen in some payloads."""
+    return len(data) >= 4 and data[:4] == b"\x27\xE3\x00\x01"
+
+
+def unpack_lz4_like(data: bytes) -> bytes:
+    """Decode the custom LZ4-like stream used by some payloads."""
+    import struct
+
+    if not data:
+        return b""
+
+    in_ptr = 0
+    out_buf = bytearray()
+    data_len = len(data)
+
+    while in_ptr < data_len:
+        token = data[in_ptr]
+        in_ptr += 1
+
+        literal_len = token >> 4
+        match_len = token & 0x0F
+
+        if literal_len == 15:
+            while True:
+                if in_ptr >= data_len:
+                    break
+                byte_val = data[in_ptr]
+                in_ptr += 1
+                literal_len += byte_val
+                if byte_val != 0xFF:
+                    break
+
+        if in_ptr + literal_len > data_len:
+            break
+
+        out_buf.extend(data[in_ptr:in_ptr + literal_len])
+        in_ptr += literal_len
+
+        if in_ptr >= data_len:
+            break
+
+        if in_ptr + 2 > data_len:
+            break
+
+        offset = struct.unpack('<H', data[in_ptr:in_ptr + 2])[0]
+        in_ptr += 2
+
+        if match_len == 15:
+            while True:
+                if in_ptr >= data_len:
+                    break
+                byte_val = data[in_ptr]
+                in_ptr += 1
+                match_len += byte_val
+                if byte_val != 0xFF:
+                    break
+
+        match_len += 4
+
+        start_pos = len(out_buf) - offset
+        if start_pos < 0:
+            break
+
+        for i in range(match_len):
+            if start_pos + i >= len(out_buf):
+                break
+            out_buf.append(out_buf[start_pos + i])
+
+    return bytes(out_buf)
+
+
 def check_nxs3(entry: NPKEntry) -> bool:
     """Check if the data is wrapped in NXS3 format."""
     return entry.data[:8] == b"NXS3\x03\x00\x00\x01"

--- a/core/npk/detection.py
+++ b/core/npk/detection.py
@@ -104,6 +104,8 @@ def _get_binary_ext(data: bytes, flags: NPKEntryDataFlags):
         return 'jpg'
     if data[:4] == b'BKHD':
         return 'bnk'
+    if data[:4] == b'8BPS':
+        return 'psd'
     if data[:4] == b'TZif':
         return 'tzif'
     if data[6:10] == b'JFIF':
@@ -278,7 +280,7 @@ def get_file_category(extension):
 
     # Textures
     if extension in ["bmp", "gif", "jpg", "jpeg", "png", "pbm", "pgm", "ppm", "xbm",
-                     "xpm", "tga", "ico", "tiff", "dds", "pvr", "astc", "ktx", "ktx_low", "cbk"]:
+                     "xpm", "tga", "ico", "tiff", "dds", "pvr", "astc", "ktx", "ktx_low", "cbk", "psd"]:
         return NPKEntryFileCategories.TEXTURE
 
     # 3D Models

--- a/core/npk/npk_file.py
+++ b/core/npk/npk_file.py
@@ -9,9 +9,9 @@ from arc4 import ARC4
 from core.binary_readers import read_uint32, read_uint16, read_uint64
 from core.npk.decompression import check_nxs3, decompress_entry, unpack_nxs3, check_rotor, unpack_rotor
 from core.npk.decryption import decrypt_entry
-from core.npk.enums import NPKFileType, NPKEntryFileCategories
+from core.npk.enums import NPKFileType
 from core.logger import get_logger
-from core.xml_converter import xml_handler, parse_handler
+from core.formats import process_entry_with_processors
 
 from .detection import get_ext, get_file_category, is_binary
 from .keys import KeyGenerator
@@ -281,18 +281,14 @@ class NPKFile:
         if not binary:
             entry.data_flags |= NPKEntryDataFlags.TEXT
 
-        # Detect file extension
-        entry.extension = get_ext(entry.data, entry.data_flags)
+        # Detect the extension before any optional post-processing so raw exports can preserve it.
+        entry.source_extension = get_ext(entry.data, entry.data_flags)
 
+        processed = process_entry_with_processors(entry)
+        if processed and not is_binary(entry.data):
+            entry.data_flags |= NPKEntryDataFlags.TEXT
+
+        entry.extension = entry.extension or get_ext(entry.data, entry.data_flags)
         entry.category = get_file_category(entry.extension)
-
-        """
-        The XML type I defined is reserved for 'C1 59 41 0D' signed files. Those files are NeoX XMLs that Breadth-First Search (BFS) sorted binary files corresponds to XML files.
-        """
-        if entry.category == NPKEntryFileCategories.XML:
-            try:
-                entry.data = bytes(xml_handler.ExportXML(*parse_handler.parseCustomBinFormat(entry.data)), encoding="utf-8")
-            except Exception:
-                pass
 
         get_logger().debug("Entry %s: %s", entry.filename, entry.category)

--- a/core/npk/npk_file.py
+++ b/core/npk/npk_file.py
@@ -1,13 +1,14 @@
 """NPK File Reader"""
 
 import io
+import os
 
 from typing import List, Dict
 
 from arc4 import ARC4
 
 from core.binary_readers import read_uint32, read_uint16, read_uint64
-from core.npk.decompression import check_nxs3, decompress_entry, unpack_nxs3, check_rotor, unpack_rotor
+from core.npk.decompression import check_lz4_like, check_nxs3, decompress_entry, unpack_lz4_like, unpack_nxs3, check_rotor, unpack_rotor, strip_none_wrapper
 from core.npk.decryption import decrypt_entry
 from core.npk.enums import NPKFileType
 from core.logger import get_logger
@@ -20,7 +21,7 @@ from .class_types import NPKEntryDataFlags, NPKIndex, NPKEntry, CompressionType,
 class NPKFile:
     """Main class for handling NPK files."""
 
-    def __init__(self, file_path: str, options: NPKReadOptions = NPKReadOptions()):
+    def __init__(self, file_path: str, options: NPKReadOptions | None = None):
         """Initialize the NPK file handler.
 
         Args:
@@ -38,7 +39,7 @@ class NPKFile:
         self.info_size: int = 0
 
         # Options when reading the NPK file
-        self.options = options
+        self.options = options if options is not None else NPKReadOptions()
 
         # NXFN file information
         self.nxfn_files = None
@@ -170,13 +171,21 @@ class NPKFile:
                 index.encrypt_flag = DecryptionType(encrypt_flag)
 
                 # Store file structure name if available
-                index.file_structure = self.nxfn_files[i] if self.nxfn_files else None
+                if self.nxfn_files and i < len(self.nxfn_files):
+                    index.file_structure = self.nxfn_files[i]
+                else:
+                    index.file_structure = None
 
                 get_logger().debug("Index %d: %s", i, index)
 
                 # Generate a filename
-                index.filename = f"{index.file_structure.decode("utf-8")
-                                    if index.file_structure else hex(index.file_signature)}"
+                if index.file_structure:
+                    try:
+                        index.filename = index.file_structure.decode("utf-8")
+                    except UnicodeDecodeError:
+                        index.filename = hex(index.file_signature)
+                else:
+                    index.filename = hex(index.file_signature)
 
                 self.indices.append(index)
 
@@ -226,9 +235,11 @@ class NPKFile:
             # Load the actual data
             self._load_entry_data(entry, file)
 
-        # Update filename with extension (or omits it if its already defined by NXFN)
-        entry.filename = entry.filename if self.hash_mode == 2 or self.encrypt_mode == 256 else \
-            f"{entry.filename}.{entry.extension}"
+        # Update filename with extension.
+        # For NXFN-backed names, keep an existing extension, otherwise append the detected one.
+        _base_name, existing_ext = os.path.splitext(entry.filename)
+        if not existing_ext and entry.extension:
+            entry.filename = f"{entry.filename}.{entry.extension}"
 
         # Store in the cache
         self.entries[index] = entry
@@ -266,15 +277,45 @@ class NPKFile:
                     entry.data_flags |= NPKEntryDataFlags.ERROR
                 return
 
-        # Check for ROTOR encryptiom
-        if check_rotor(entry):
-            entry.data_flags |= NPKEntryDataFlags.ROTOR_PACKED
-            entry.data = unpack_rotor(entry.data)
+        # Continuously strip simple wrappers and unpack nested payloads.
+        entry.unwrap_layers = []
+        seen_signatures: set[tuple[int, bytes]] = set()
+        max_layers = 32
+        for _ in range(max_layers):
+            signature = (len(entry.data), entry.data[:16])
+            if signature in seen_signatures:
+                break
+            seen_signatures.add(signature)
 
-        # Check for NXS3 wrapping
-        if check_nxs3(entry):
-            entry.data_flags |= NPKEntryDataFlags.NXS3_PACKED
-            entry.data = unpack_nxs3(entry.data)
+            stripped = strip_none_wrapper(entry.data)
+            if stripped != entry.data:
+                entry.data = stripped
+                entry.unwrap_layers.append("NONE")
+                continue
+
+            if check_lz4_like(entry.data):
+                try:
+                    unpacked = unpack_lz4_like(entry.data)
+                except Exception:
+                    break
+                if unpacked and unpacked != entry.data:
+                    entry.data = unpacked
+                    entry.unwrap_layers.append("LZ4_LIKE")
+                    continue
+
+            if check_rotor(entry):
+                entry.data_flags |= NPKEntryDataFlags.ROTOR_PACKED
+                entry.data = unpack_rotor(entry.data)
+                entry.unwrap_layers.append("ROTOR")
+                continue
+
+            if check_nxs3(entry):
+                entry.data_flags |= NPKEntryDataFlags.NXS3_PACKED
+                entry.data = unpack_nxs3(entry.data)
+                entry.unwrap_layers.append("NXS3")
+                continue
+
+            break
 
         binary = is_binary(entry.data)
         # Mark the data as text data

--- a/core/wpk/__init__.py
+++ b/core/wpk/__init__.py
@@ -1,0 +1,3 @@
+from .wpk_file import IDXWPKFile
+
+__all__ = ["IDXWPKFile"]

--- a/core/wpk/constants.py
+++ b/core/wpk/constants.py
@@ -1,0 +1,7 @@
+"""Shared constants for IDX/WPK readers."""
+
+IDX_HEAD_SIZE = 0x20
+IDX_REC_SIZE = 0x24
+WPK_MAGIC = b"FKPW"
+EMBEDDED_MAGIC = b"1DPW"
+MIN_EMBEDDED_HEADER_SIZE = 0x30

--- a/core/wpk/decryption.py
+++ b/core/wpk/decryption.py
@@ -1,0 +1,142 @@
+"""WPK/WPD1 payload stage-1 decoding helpers."""
+
+from __future__ import annotations
+
+import struct
+from typing import Optional
+
+from core.logger import get_logger
+
+try:
+    from cryptography.hazmat.backends import default_backend as aes_default_backend
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+    _HAS_AES = True
+except Exception:  # pragma: no cover - graceful fallback
+    Cipher = algorithms = modes = None
+    aes_default_backend = None
+    _HAS_AES = False
+
+
+def _u16(b: bytes) -> int:
+    return int.from_bytes(b, "little")
+
+
+def derive_key(length: int, t: int) -> bytes:
+    """Derive the 16-byte AES key used by WPD1 stage-1."""
+    v10 = (t + (length & 0xFFFFFFFF)) & 0xFF
+    v28 = (
+        0x7C2E6B6A00000000
+        | (((length & 0xFFFFFFFF) << 8) & 0xFFFF0000)
+        | (v10 << 8)
+        | (length % 0xFD)
+    )
+    v29 = (
+        0x5C74656E00003630
+        | (((v10 ^ 0x33) << 16) & 0xFFFFFFFF00FFFFFF)
+        | ((v10 | 0x2E) << 24)
+    )
+    return struct.pack("<QQ", v28 & 0xFFFFFFFFFFFFFFFF, v29 & 0xFFFFFFFFFFFFFFFF)
+
+
+def aes_decrypt_prefix(buf: bytearray, length: int, key16: bytes) -> int:
+    """AES-ECB decrypt the prefix aligned to 16-byte blocks."""
+    if length <= 0 or not _HAS_AES:
+        return 0
+
+    done = (length // 16) * 16
+    if done <= 0:
+        return 0
+
+    cipher = Cipher(algorithms.AES(key16), modes.ECB(), backend=aes_default_backend())
+    dec = cipher.decryptor()
+    buf[:done] = dec.update(bytes(buf[:done])) + dec.finalize()
+    return done
+
+
+def xor_offset(buf: bytearray, offset: int, want: int, seed: int) -> None:
+    if want <= 0:
+        return
+
+    mirror_len = min(offset, want)
+    for i in range(mirror_len):
+        buf[offset + i] ^= ((seed + i) + buf[i]) & 0xFF
+
+    for i in range(want - mirror_len):
+        buf[offset + mirror_len + i] ^= (seed + mirror_len + i) & 0xFF
+
+
+def xor_linear(buf: bytearray, want: int, seed: int) -> None:
+    for i in range(want):
+        buf[i] ^= (seed + i) & 0xFF
+
+
+def header_decode(buf: bytearray) -> None:
+    n = min(64, len(buf))
+    i, j = 0, n - 1
+    while i < j:
+        bi = buf[i] ^ 0x5A
+        bj = buf[j] ^ 0x5A
+        buf[i], buf[j] = bj, bi
+        i += 1
+        j -= 1
+    if i == j:
+        buf[i] ^= 0x5A
+
+
+def decode_payload_stage1(payload: bytes, *, skip_header_decode: bool = False) -> tuple[bytes, int] | None:
+    """Decode one payload using the WPD1 stage-1 rules.
+
+    Returns (decoded_body, tag) on success, or None if the payload does not
+    match a supported stage-1 variant.
+    """
+    if len(payload) < 8:
+        return None
+
+    tag = _u16(payload[0:2])
+    p = payload[2]
+    t = payload[3]
+    body = bytearray(payload[8:])
+    body_len = len(body)
+    prefix_len = min(body_len, 128 << (p - 1)) if body_len > 0 and p != 0 else 0
+    seed = (t + body_len) & 0xFFFFFFFF
+
+    if tag in (0x4341, 0x4350):
+        key = derive_key(body_len, t)
+        done = aes_decrypt_prefix(body, prefix_len, key)
+        remain = max(0, prefix_len - done)
+        if remain > 0:
+            xor_offset(body, done, remain, seed)
+    elif tag == 0x4358:
+        xor_linear(body, prefix_len, seed)
+    else:
+        return None
+
+    if not skip_header_decode:
+        header_decode(body)
+    return bytes(body), tag
+
+
+def try_decode_payload_stage1(
+    payload: bytes,
+    *,
+    context: str = "",
+    skip_header_decode: bool = False,
+) -> tuple[bytes, bool, int | None]:
+    """Best-effort wrapper around stage-1 decoding.
+
+    Returns (data, decoded, tag).
+    """
+    try:
+        result = decode_payload_stage1(payload, skip_header_decode=skip_header_decode)
+    except Exception as exc:  # pragma: no cover - defensive logging path
+        if context:
+            get_logger().debug("WPD1 stage1 failed for %s: %s", context, exc)
+        else:
+            get_logger().debug("WPD1 stage1 failed: %s", exc)
+        return payload, False, None
+
+    if result is None:
+        return payload, False, None
+
+    decoded, tag = result
+    return decoded, True, tag

--- a/core/wpk/idx_reader.py
+++ b/core/wpk/idx_reader.py
@@ -1,0 +1,102 @@
+"""IDX-specific parsing helpers."""
+
+from __future__ import annotations
+
+import os
+from collections import Counter
+
+from core.logger import get_logger
+from core.npk.class_types import NPKIndex
+
+from .constants import IDX_HEAD_SIZE, IDX_REC_SIZE
+
+
+def read_idx_header(reader, file) -> None:
+    """Read the header of a SKPW IDX file."""
+    magic = file.read(4)
+    if magic != b"SKPW":
+        raise ValueError(f"Not a valid WPKS (.idx) file: {reader.idx_path}")
+
+    file.seek(0x0C)
+    reader.file_count = int.from_bytes(file.read(4), "little")
+
+    get_logger().info("Archive type: WPKS (.idx)")
+    get_logger().info("Entry count: %d", reader.file_count)
+
+
+def read_idx_indices(reader, file) -> None:
+    """Read all fixed-size IDX records into NPKIndex entries."""
+    reader.indices = []
+    file.seek(IDX_HEAD_SIZE)
+
+    for i in range(reader.file_count):
+        rec = file.read(IDX_REC_SIZE)
+        if len(rec) != IDX_REC_SIZE:
+            raise EOFError(f"IDX truncated while reading record {i}")
+
+        index = NPKIndex()
+
+        raw_hash = rec[0x00:0x10]
+        pkg_id = rec[0x14]
+        file_off_hdr = int.from_bytes(rec[0x18:0x1C], "little")
+        payload_size = int.from_bytes(rec[0x1C:0x20], "little")
+        hdr_size = int.from_bytes(rec[0x20:0x22], "little")
+        total_size = hdr_size + payload_size
+
+        index.file_signature = int.from_bytes(raw_hash, "little")
+        index.file_offset = file_off_hdr
+        index.file_length = total_size
+        index.file_original_length = total_size
+        index.zcrc = 0
+        index.crc = 0
+        index.file_structure = None
+        index.filename = raw_hash.hex()
+
+        index.pkg_id = pkg_id
+        index.hdr_size = hdr_size
+        index.payload_size = payload_size
+        index.raw_hash_hex = raw_hash.hex()
+
+        reader.indices.append(index)
+        get_logger().debug(
+            "IDX record %d: pkg=%d off=0x%X hdr=%d payload=%d name=%s",
+            i,
+            pkg_id,
+            file_off_hdr,
+            hdr_size,
+            payload_size,
+            index.filename,
+        )
+
+    log_idx_split_summary(reader)
+
+
+def log_idx_split_summary(reader) -> None:
+    """Log how many IDX entries point to each WPK package or slot_file."""
+    pkg_counts = Counter(int(getattr(index, "pkg_id", -1)) for index in reader.indices)
+    if not pkg_counts:
+        return
+
+    get_logger().info("IDX split summary for %s", os.path.basename(reader.idx_path or reader.file_path))
+
+    slot_file_count = 0
+    for pkg_id in sorted(pkg_counts):
+        count = pkg_counts[pkg_id]
+        if reader._is_slot_file_pkg(pkg_id):
+            slot_file_count += count
+            continue
+
+        resolved_path = reader._find_wpk_path(pkg_id)
+        label = os.path.basename(resolved_path) if os.path.exists(resolved_path) else f"package {pkg_id}"
+        get_logger().info("  %s -> %d files", label, count)
+
+    if slot_file_count:
+        slot_dir = reader._get_slot_file_dir()
+        actual_slot_files = 0
+        if slot_dir.is_dir():
+            actual_slot_files = sum(1 for p in slot_dir.iterdir() if p.is_file())
+        get_logger().info(
+            "  slot_file -> %d indexed entries%s",
+            slot_file_count,
+            f" ({actual_slot_files} files in {slot_dir.name}/)" if actual_slot_files else "",
+        )

--- a/core/wpk/paths.py
+++ b/core/wpk/paths.py
@@ -1,0 +1,88 @@
+"""Path and file-handle helpers for IDX/WPK archives."""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import BinaryIO
+
+from core.logger import get_logger
+
+
+class WPKPathResolver:
+    """Resolve package ids to WPK files and keep open-file handles cached."""
+
+    def __init__(self, reader):
+        self.reader = reader
+
+    def iter_wpk_path_candidates(self, pkg_id: int):
+        seen = set()
+
+        def push(candidate: str):
+            if not candidate:
+                return
+            candidate = os.path.normpath(candidate)
+            if candidate in seen:
+                return
+            seen.add(candidate)
+            yield candidate
+
+        custom = self.reader._wpk_paths.get(pkg_id)
+        if custom:
+            yield from push(custom)
+
+        stem = re.escape(self.reader.base_stem)
+        regex = re.compile(rf"^{stem}_?0*{int(pkg_id)}\.wpk$", re.IGNORECASE)
+
+        direct_candidates = [
+            os.path.join(self.reader.base_dir, f"{self.reader.base_stem}{pkg_id}.wpk"),
+            os.path.join(self.reader.base_dir, f"{self.reader.base_stem}_{pkg_id}.wpk"),
+        ]
+        for candidate in direct_candidates:
+            yield from push(candidate)
+
+        try:
+            for name in sorted(os.listdir(self.reader.base_dir)):
+                if regex.fullmatch(name):
+                    yield from push(os.path.join(self.reader.base_dir, name))
+        except OSError:
+            return
+
+    def find_wpk_path(self, pkg_id: int) -> str:
+        if self.reader.mode == "wpk":
+            assert self.reader.wpk_path is not None
+            return self.reader.wpk_path
+
+        for candidate in self.iter_wpk_path_candidates(pkg_id):
+            if os.path.exists(candidate):
+                self.reader._wpk_paths[pkg_id] = candidate
+                return candidate
+
+        custom = self.reader._wpk_paths.get(pkg_id)
+        if custom:
+            return custom
+
+        return os.path.join(self.reader.base_dir, f"{self.reader.base_stem}{pkg_id}.wpk")
+
+    def is_slot_file_pkg(self, pkg_id: int) -> bool:
+        return not (0 <= int(pkg_id) <= 15)
+
+    def get_slot_file_dir(self) -> Path:
+        stem = self.reader.base_stem
+        slot_name = re.sub(r"\d+$", "", stem) or stem
+        return Path(self.reader.base_dir) / slot_name
+
+    def get_wpk_handle(self, pkg_id: int) -> BinaryIO | None:
+        if pkg_id in self.reader._wpk_cache:
+            return self.reader._wpk_cache[pkg_id]
+
+        wpk_path = self.find_wpk_path(pkg_id)
+        if not os.path.exists(wpk_path):
+            get_logger().warning("WPK not found for pkg_id=%d: %s", pkg_id, wpk_path)
+            self.reader._wpk_cache[pkg_id] = None
+            return None
+
+        handle = open(wpk_path, "rb")
+        self.reader._wpk_cache[pkg_id] = handle
+        return handle

--- a/core/wpk/payload.py
+++ b/core/wpk/payload.py
@@ -1,0 +1,346 @@
+"""Payload decoding and nested wrapper unwrapping for WPK entries."""
+
+from __future__ import annotations
+
+import struct
+import zlib
+
+from core.logger import get_logger
+from core.npk.class_types import NPKEntry, NPKEntryDataFlags
+from core.npk.detection import get_ext, is_binary
+from core.npk.decompression import (
+    check_lz4_like,
+    check_nxs3,
+    check_rotor,
+    strip_none_wrapper,
+    unpack_lz4_like,
+    unpack_nxs3,
+    unpack_rotor,
+)
+from core.wpk.decryption import try_decode_payload_stage1
+
+
+class WPKPayloadProcessor:
+    """Decode WPK payloads, including slot_file heuristics and nested wrappers."""
+
+    def maybe_unpack_dtsz(self, data: bytes, *, context: str) -> tuple[bytes, bool]:
+        if len(data) < 8 or data[:4] != b"DTSZ" or data[4:8] != b"\x28\xB5\x2F\xFD":
+            return data, False
+
+        try:
+            import zstandard
+        except Exception as exc:
+            get_logger().debug("DTSZ support unavailable for %s: %s", context, exc)
+            return data, False
+
+        try:
+            unpacked = zstandard.ZstdDecompressor().decompress(data[4:])
+            get_logger().debug("DTSZ unpacked: %s in=%d out=%d", context, len(data), len(unpacked))
+            return unpacked, True
+        except Exception as exc:
+            get_logger().warning("DTSZ decompress failed for %s: %s", context, exc)
+            return data, False
+
+    def maybe_strip_enon_header(self, data: bytes, *, context: str) -> tuple[bytes, bool]:
+        if len(data) < 4 or data[:4] != b"ENON":
+            return data, False
+
+        stripped = data[4:]
+        get_logger().debug("ENON header stripped: %s in=%d out=%d", context, len(data), len(stripped))
+        return stripped, True
+
+    def unwrap_nested_payloads(self, entry: NPKEntry, *, context: str) -> None:
+        entry.none_header_stripped = bool(getattr(entry, "none_header_stripped", False))
+        entry.enon_header_stripped = bool(getattr(entry, "enon_header_stripped", False))
+        entry.dtsz_unpacked = bool(getattr(entry, "dtsz_unpacked", False))
+        entry.cobl_unpacked = bool(getattr(entry, "cobl_unpacked", False))
+        entry.unwrap_layers = list(getattr(entry, "unwrap_layers", []))
+
+        seen_signatures: set[tuple[int, bytes]] = set()
+        max_layers = 32
+        for _ in range(max_layers):
+            signature = (len(entry.data), entry.data[:16])
+            if signature in seen_signatures:
+                get_logger().debug(
+                    "Nested payload unwrap stopped on repeated signature: %s len=%d head=%s layers=%s",
+                    context,
+                    len(entry.data),
+                    entry.data[:8].hex().upper(),
+                    ",".join(entry.unwrap_layers) if entry.unwrap_layers else "-",
+                )
+                break
+            seen_signatures.add(signature)
+
+            stripped = strip_none_wrapper(entry.data)
+            if stripped != entry.data:
+                get_logger().debug("NONE header stripped: %s in=%d out=%d", context, len(entry.data), len(stripped))
+                entry.data = stripped
+                entry.none_header_stripped = True
+                entry.unwrap_layers.append("NONE")
+                continue
+
+            stripped, did_strip = self.maybe_strip_enon_header(entry.data, context=context)
+            if did_strip:
+                entry.data = stripped
+                entry.enon_header_stripped = True
+                entry.unwrap_layers.append("ENON")
+                continue
+
+            unpacked, did_unpack = self.maybe_unpack_dtsz(entry.data, context=context)
+            if did_unpack:
+                entry.data = unpacked
+                entry.dtsz_unpacked = True
+                entry.unwrap_layers.append("DTSZ")
+                continue
+
+            unpacked, did_unpack = self.maybe_unpack_cobl(entry.data, context=context)
+            if did_unpack:
+                entry.data = unpacked
+                entry.cobl_unpacked = True
+                entry.unwrap_layers.append("COBL")
+                continue
+
+            if check_lz4_like(entry.data):
+                before_len = len(entry.data)
+                try:
+                    unpacked = unpack_lz4_like(entry.data)
+                except Exception as exc:
+                    get_logger().warning("LZ4-like unpack failed for %s: %s", context, exc)
+                    break
+
+                if unpacked and unpacked != entry.data:
+                    entry.data = unpacked
+                    get_logger().debug("LZ4-like unpacked: %s in=%d out=%d", context, before_len, len(entry.data))
+                    entry.unwrap_layers.append("LZ4_LIKE")
+                    continue
+
+            if check_rotor(entry):
+                before_len = len(entry.data)
+                entry.data_flags |= NPKEntryDataFlags.ROTOR_PACKED
+                entry.data = unpack_rotor(entry.data)
+                get_logger().debug("ROTOR unpacked: %s in=%d out=%d", context, before_len, len(entry.data))
+                entry.unwrap_layers.append("ROTOR")
+                continue
+
+            if check_nxs3(entry):
+                before_len = len(entry.data)
+                entry.data_flags |= NPKEntryDataFlags.NXS3_PACKED
+                entry.data = unpack_nxs3(entry.data)
+                get_logger().debug("NXS3 unpacked: %s in=%d out=%d", context, before_len, len(entry.data))
+                entry.unwrap_layers.append("NXS3")
+                continue
+
+            break
+        else:
+            get_logger().warning(
+                "Nested payload unwrap hit layer limit: %s layers=%s final_len=%d head=%s",
+                context,
+                ",".join(entry.unwrap_layers) if entry.unwrap_layers else "-",
+                len(entry.data),
+                entry.data[:8].hex().upper(),
+            )
+
+    def maybe_unpack_cobl(self, data: bytes, *, context: str) -> tuple[bytes, bool]:
+        if len(data) < 16 or data[:4] not in (b"LBOC", b"COBL"):
+            return data, False
+
+        try:
+            unpacked = self.decode_cobl_concat(data, context=context)
+            if not unpacked:
+                get_logger().debug("COBL decode produced empty output for %s", context)
+                return data, False
+
+            get_logger().debug("COBL unpacked: %s in=%d out=%d", context, len(data), len(unpacked))
+            return unpacked, True
+        except Exception as exc:
+            get_logger().warning("COBL decode failed for %s: %s", context, exc)
+            return data, False
+
+    def decode_cobl_concat(self, data: bytes, *, context: str) -> bytes:
+        magic, field04, field08, block_count = struct.unpack_from("<4I", data, 0)
+        if magic != 0x434F424C:
+            raise ValueError(f"bad COBL magic 0x{magic:08X}")
+
+        data_base = 16 + block_count * 8
+        if len(data) < data_base:
+            raise ValueError(f"COBL truncated block table: need >= {data_base}, got {len(data)}")
+
+        rel_offset = 0
+        out = bytearray()
+
+        for block_index in range(block_count):
+            size, extra, unk = struct.unpack_from("<IHH", data, 16 + block_index * 8)
+            start = data_base + rel_offset
+            end = start + size
+            if end > len(data):
+                raise ValueError(
+                    f"COBL block {block_index} out of range: start={start} end={end} size={len(data)}"
+                )
+
+            payload = data[start:end]
+            decoded = self.decode_cobl_block(payload, context=f"{context} block={block_index}")
+            out.extend(decoded)
+            rel_offset += size + extra
+
+        return bytes(out)
+
+    def decode_cobl_block(self, data: bytes, *, context: str) -> bytes:
+        if not data:
+            return b""
+
+        patched, probe_len = self.deobfuscate_cobl_probe_region(data)
+        if probe_len < 4 or len(patched) < 4:
+            return data
+
+        tag = struct.unpack_from("<I", patched, 0)[0]
+        payload = patched[4:]
+
+        if tag == 0x4E4F4E45:
+            return payload
+
+        if tag == 0x5A4C4942:
+            return zlib.decompress(payload)
+
+        if tag == 0x5A535444:
+            try:
+                import zstandard
+            except Exception as exc:
+                raise RuntimeError(f"COBL block requires zstandard for {context}: {exc}") from exc
+            return zstandard.ZstdDecompressor().decompress(payload)
+
+        if tag == 0x4C5A3446:
+            try:
+                import lz4.frame as lz4f
+            except Exception as exc:
+                raise RuntimeError(f"COBL block requires lz4.frame for {context}: {exc}") from exc
+            return lz4f.decompress(payload)
+
+        if tag == 0x4F4F444C:
+            raise RuntimeError(f"COBL block uses unsupported Oodle codec for {context}")
+
+        return data
+
+    def deobfuscate_cobl_probe_region(self, data: bytes) -> tuple[bytes, int]:
+        if not data:
+            return data, 0
+
+        probe_len = min(64, len(data))
+        if probe_len <= 3:
+            return data, 0
+
+        chunk = data[:probe_len]
+        fixed = bytes((b ^ 0x5A) for b in chunk[::-1])
+
+        patched = bytearray(data)
+        patched[:probe_len] = fixed
+        return bytes(patched), probe_len
+
+    def score_slot_stage1_candidate(self, data: bytes) -> tuple[int, str]:
+        if not data:
+            return -1000, "empty"
+
+        score = 0
+        reasons: list[str] = []
+
+        known_heads = {
+            b"ENON": 140,
+            b"NXS3": 140,
+            b"LBOC": 140,
+            b"RIFF": 120,
+            b"OggS": 120,
+            b"FSB5": 120,
+            b"BKHD": 120,
+            b"DDS ": 120,
+            b"PVR": 120,
+            b"RGIS": 120,
+            b"VANT": 120,
+            b"NTRK": 120,
+            b"PK\x03\x04": 120,
+            b"CompBlks": 120,
+            b"SKELETON": 120,
+            b"NEOXBIN1": 120,
+            b"NEOXMESH": 120,
+            b"RAWANIMA": 120,
+        }
+
+        for magic, bonus in known_heads.items():
+            if data.startswith(magic):
+                score += bonus
+                reasons.append(f"magic={magic.decode('latin1', errors='ignore')}")
+                break
+
+        head = data[:64]
+        if head:
+            z5a = head.count(0x5A)
+            if z5a >= 16:
+                penalty = min(80, z5a * 2)
+                score -= penalty
+                reasons.append(f"z5a={z5a}")
+
+            unique = len(set(head))
+            if unique <= 8:
+                score -= 40
+                reasons.append(f"uniq={unique}")
+            elif unique >= 24:
+                score += 15
+                reasons.append(f"uniq={unique}")
+
+        flags = NPKEntryDataFlags(0)
+        if not is_binary(data):
+            flags |= NPKEntryDataFlags.TEXT
+
+        ext = get_ext(data, flags)
+        if ext != "dat":
+            score += 80
+            reasons.append(f"ext={ext}")
+        elif data[:4].isalpha():
+            score += 20
+            reasons.append("alpha_head")
+
+        nul_ratio = data[:64].count(0) / max(1, len(data[:64]))
+        if 0.10 <= nul_ratio <= 0.75:
+            score += 10
+            reasons.append("structured_nuls")
+
+        return score, ",".join(reasons) if reasons else "none"
+
+    def decode_slot_payload_auto(self, payload: bytes, *, context: str) -> tuple[bytes, bool, int | None, bool]:
+        with_header, with_decoded, with_tag = try_decode_payload_stage1(
+            payload,
+            context=f"{context} slot_auto with_header",
+            skip_header_decode=False,
+        )
+        no_header, no_decoded, no_tag = try_decode_payload_stage1(
+            payload,
+            context=f"{context} slot_auto no_header",
+            skip_header_decode=True,
+        )
+
+        if with_decoded and no_decoded:
+            with_score, with_reason = self.score_slot_stage1_candidate(with_header)
+            no_score, no_reason = self.score_slot_stage1_candidate(no_header)
+
+            choose_no_header = no_score > with_score
+            chosen = no_header if choose_no_header else with_header
+            chosen_tag = no_tag if choose_no_header else with_tag
+
+            get_logger().debug(
+                "slot_file auto-select: %s with_header(score=%d,%s) no_header(score=%d,%s) -> %s",
+                context,
+                with_score,
+                with_reason,
+                no_score,
+                no_reason,
+                "no_header" if choose_no_header else "with_header",
+            )
+            return chosen, True, chosen_tag, choose_no_header
+
+        if no_decoded:
+            get_logger().debug("slot_file auto-select: %s only no_header decoded", context)
+            return no_header, True, no_tag, True
+
+        if with_decoded:
+            get_logger().debug("slot_file auto-select: %s only with_header decoded", context)
+            return with_header, True, with_tag, False
+
+        return payload, False, None, False

--- a/core/wpk/slot_file.py
+++ b/core/wpk/slot_file.py
@@ -1,0 +1,93 @@
+"""slot_file location and cached directory indexing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from core.logger import get_logger
+from core.npk.class_types import NPKEntry
+
+
+@dataclass
+class SlotDirectoryIndex:
+    """Cached lookup tables for one slot_file directory."""
+
+    exact_name: dict[str, Path] = field(default_factory=dict)
+    exact_stem: dict[str, list[Path]] = field(default_factory=dict)
+    ordered_files: list[Path] = field(default_factory=list)
+
+
+class SlotFileResolver:
+    """Resolve IDX slot_file entries against a directory on disk."""
+
+    def __init__(self, reader):
+        self.reader = reader
+        self._dir_index_cache: dict[Path, SlotDirectoryIndex] = {}
+
+    def read_slot_file_data(self, entry: NPKEntry) -> bytes | None:
+        slot_dir = self.reader._get_slot_file_dir()
+        if not slot_dir.is_dir():
+            return None
+
+        dir_index = self._get_dir_index(slot_dir)
+        raw_hash_hex = getattr(entry, "raw_hash_hex", "") or entry.filename.split(".", 1)[0]
+
+        candidate_paths: list[Path] = []
+        for key in (raw_hash_hex, entry.filename):
+            path = dir_index.exact_name.get(key)
+            if path is not None:
+                candidate_paths.append(path)
+
+        candidate_paths.extend(dir_index.exact_stem.get(raw_hash_hex, []))
+
+        seen = set()
+        for candidate in candidate_paths:
+            candidate_str = str(candidate)
+            if candidate_str in seen:
+                continue
+            seen.add(candidate_str)
+            if candidate.is_file():
+                get_logger().debug(
+                    "Loading slot_file from %s for pkg_id=%s name=%s",
+                    candidate,
+                    getattr(entry, "pkg_id", None),
+                    raw_hash_hex,
+                )
+                return candidate.read_bytes()
+
+        for path in dir_index.ordered_files:
+            if path.stem.startswith(raw_hash_hex):
+                get_logger().debug(
+                    "Loading slot_file by prefix from %s for pkg_id=%s name=%s",
+                    path,
+                    getattr(entry, "pkg_id", None),
+                    raw_hash_hex,
+                )
+                return path.read_bytes()
+
+        return None
+
+    def _get_dir_index(self, slot_dir: Path) -> SlotDirectoryIndex:
+        cached = self._dir_index_cache.get(slot_dir)
+        if cached is not None:
+            return cached
+
+        exact_name: dict[str, Path] = {}
+        exact_stem: dict[str, list[Path]] = {}
+        ordered_files: list[Path] = []
+
+        for path in sorted(slot_dir.iterdir()):
+            if not path.is_file():
+                continue
+            ordered_files.append(path)
+            exact_name.setdefault(path.name, path)
+            exact_stem.setdefault(path.stem, []).append(path)
+
+        dir_index = SlotDirectoryIndex(
+            exact_name=exact_name,
+            exact_stem=exact_stem,
+            ordered_files=ordered_files,
+        )
+        self._dir_index_cache[slot_dir] = dir_index
+        return dir_index

--- a/core/wpk/standalone.py
+++ b/core/wpk/standalone.py
@@ -1,0 +1,111 @@
+"""Standalone FKPW WPK scanning helpers."""
+
+from __future__ import annotations
+
+import os
+
+from core.logger import get_logger
+from core.npk.class_types import NPKIndex
+
+from .constants import EMBEDDED_MAGIC, MIN_EMBEDDED_HEADER_SIZE, WPK_MAGIC
+
+
+def read_wpk_header(reader, file) -> None:
+    """Read a standalone WPK header and store archive size."""
+    magic = file.read(4)
+    if magic != WPK_MAGIC:
+        raise ValueError(f"Not a valid WPKF (.wpk) file: {reader.wpk_path}")
+
+    file.seek(0, os.SEEK_END)
+    reader._wpk_size = file.tell()
+    file.seek(0)
+
+    get_logger().info("Archive type: WPKF standalone .wpk")
+    get_logger().info("WPK size: %d bytes", reader._wpk_size)
+
+
+def scan_wpk_indices(reader, file) -> None:
+    """Scan embedded 1DPW entries from a standalone WPK container."""
+    data = file.read()
+    offsets: list[int] = []
+    pos = 0
+    while True:
+        found = data.find(EMBEDDED_MAGIC, pos)
+        if found == -1:
+            break
+        offsets.append(found)
+        pos = found + 1
+
+    reader.indices = []
+    if not offsets:
+        reader.file_count = 0
+        get_logger().warning("No embedded %r entries found in WPK: %s", EMBEDDED_MAGIC, reader.wpk_path)
+        return
+
+    for i, off in enumerate(offsets):
+        next_off = offsets[i + 1] if i + 1 < len(offsets) else len(data)
+        index = build_index_from_embedded_header(data, off, next_off, i)
+        reader.indices.append(index)
+
+    reader.file_count = len(reader.indices)
+    reader._wpk_paths[0] = reader.wpk_path or reader.file_path
+
+    get_logger().info("Scanned %d embedded entries from standalone WPK", reader.file_count)
+
+
+def build_index_from_embedded_header(data: bytes, off: int, next_off: int, ordinal: int) -> NPKIndex:
+    """Build an NPKIndex from one embedded WPK entry header."""
+    index = NPKIndex()
+
+    hdr_size = 0
+    payload_size = 0
+    raw_hash = b""
+
+    available = len(data) - off
+    if available >= MIN_EMBEDDED_HEADER_SIZE:
+        raw_hash = data[off + 0x08: off + 0x18]
+        payload_size = int.from_bytes(data[off + 0x20: off + 0x24], "little")
+        hdr_size = int.from_bytes(data[off + 0x24: off + 0x26], "little")
+
+    guessed_total = hdr_size + payload_size if hdr_size > 0 else 0
+    max_possible = max(0, next_off - off)
+
+    if hdr_size < MIN_EMBEDDED_HEADER_SIZE or hdr_size > max_possible:
+        hdr_size = MIN_EMBEDDED_HEADER_SIZE if max_possible >= MIN_EMBEDDED_HEADER_SIZE else max_possible
+    if guessed_total <= 0 or guessed_total > max_possible:
+        total_size = max_possible
+        if total_size >= hdr_size:
+            payload_size = total_size - hdr_size
+        else:
+            hdr_size = total_size
+            payload_size = 0
+    else:
+        total_size = guessed_total
+
+    if not raw_hash or raw_hash == b"\x00" * 16:
+        raw_hash = off.to_bytes(8, "little") + ordinal.to_bytes(8, "little")
+
+    index.file_signature = int.from_bytes(raw_hash, "little")
+    index.file_offset = off
+    index.file_length = total_size
+    index.file_original_length = total_size
+    index.zcrc = 0
+    index.crc = 0
+    index.file_structure = None
+    index.filename = raw_hash.hex()
+
+    index.pkg_id = 0
+    index.hdr_size = hdr_size
+    index.payload_size = payload_size
+    index.raw_hash_hex = raw_hash.hex()
+
+    get_logger().debug(
+        "WPK scan record %d: off=0x%X hdr=%d payload=%d total=%d name=%s",
+        ordinal,
+        off,
+        hdr_size,
+        payload_size,
+        total_size,
+        index.filename,
+    )
+    return index

--- a/core/wpk/wpk_file.py
+++ b/core/wpk/wpk_file.py
@@ -7,6 +7,7 @@ from typing import BinaryIO, Dict, List
 
 from core.logger import get_logger
 from core.npk.class_types import NPKEntryDataFlags, NPKEntry, NPKIndex, NPKReadOptions
+from core.formats import process_entry_with_processors
 from core.npk.detection import get_ext, get_file_category, is_binary
 from core.wpk.decryption import try_decode_payload_stage1
 
@@ -315,7 +316,12 @@ class IDXWPKFile:
             entry.data_flags |= NPKEntryDataFlags.TEXT
 
         entry.source_extension = get_ext(entry.data, entry.data_flags)
-        entry.extension = get_ext(entry.data, entry.data_flags)
+
+        processed = process_entry_with_processors(entry)
+        if processed and not is_binary(entry.data):
+            entry.data_flags |= NPKEntryDataFlags.TEXT
+
+        entry.extension = entry.extension or get_ext(entry.data, entry.data_flags)
         entry.category = get_file_category(entry.extension)
 
         get_logger().debug(

--- a/core/wpk/wpk_file.py
+++ b/core/wpk/wpk_file.py
@@ -1,0 +1,333 @@
+"""IDX + WPK / standalone WPK reader."""
+
+from __future__ import annotations
+
+import os
+from typing import BinaryIO, Dict, List
+
+from core.logger import get_logger
+from core.npk.class_types import NPKEntryDataFlags, NPKEntry, NPKIndex, NPKReadOptions
+from core.npk.detection import get_ext, get_file_category, is_binary
+from core.wpk.decryption import try_decode_payload_stage1
+
+from .constants import EMBEDDED_MAGIC, IDX_HEAD_SIZE, IDX_REC_SIZE, MIN_EMBEDDED_HEADER_SIZE, WPK_MAGIC
+from .idx_reader import log_idx_split_summary, read_idx_header, read_idx_indices
+from .paths import WPKPathResolver
+from .payload import WPKPayloadProcessor
+from .slot_file import SlotFileResolver
+from .standalone import build_index_from_embedded_header, read_wpk_header, scan_wpk_indices
+
+
+class IDXWPKFile:
+    """
+    Reader for:
+    - SKPW IDX + one/many WPK files
+    - direct standalone FKPW WPK scanning
+
+    Current assumptions derived from user samples:
+    - IDX magic: b"SKPW"
+    - IDX header size: 0x20
+    - IDX record size: 0x24
+    - WPK package magic: b"FKPW"
+    - Embedded entry magic inside WPK: b"1DPW"
+    - Embedded entry header size usually stored at +0x24 (u16)
+    - Embedded entry payload size usually stored at +0x20 (u32)
+    """
+
+    IDX_HEAD_SIZE = IDX_HEAD_SIZE
+    IDX_REC_SIZE = IDX_REC_SIZE
+    WPK_MAGIC = WPK_MAGIC
+    EMBEDDED_MAGIC = EMBEDDED_MAGIC
+    MIN_EMBEDDED_HEADER_SIZE = MIN_EMBEDDED_HEADER_SIZE
+
+    def __init__(self, file_path: str, options: NPKReadOptions | None = None):
+        self.file_path = file_path
+        self.options = options if options is not None else NPKReadOptions()
+
+        self.entries: Dict[int, NPKEntry] = {}
+        self.indices: List[NPKIndex] = []
+        self.file_count: int = 0
+        self._wpk_cache: Dict[int, BinaryIO | None] = {}
+        self._wpk_paths: Dict[int, str] = {}
+
+        self.mode = ""
+        self.idx_path: str | None = None
+        self.wpk_path: str | None = None
+        self.base_dir = os.path.dirname(file_path)
+        self.base_stem = os.path.splitext(os.path.basename(file_path))[0]
+
+        self._path_resolver = WPKPathResolver(self)
+        self._slot_file_resolver = SlotFileResolver(self)
+        self._payload_processor = WPKPayloadProcessor()
+
+        with open(self.file_path, "rb") as file:
+            magic = file.read(4)
+
+        if magic == b"SKPW":
+            self.mode = "idx"
+            self.idx_path = file_path
+            get_logger().info("Opening IDX file: %s", self.idx_path)
+            with open(self.idx_path, "rb") as file:
+                self._read_idx_header(file)
+                self._read_idx_indices(file)
+        elif magic == self.WPK_MAGIC:
+            self.mode = "wpk"
+            self.wpk_path = file_path
+            get_logger().info("Opening standalone WPK file: %s", self.wpk_path)
+            with open(self.wpk_path, "rb") as file:
+                self._read_wpk_header(file)
+                self._scan_wpk_indices(file)
+        else:
+            raise ValueError(f"Unsupported IDX/WPK file type: {file_path}")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()
+
+    def close(self):
+        for handle in self._wpk_cache.values():
+            if handle is not None:
+                try:
+                    handle.close()
+                except Exception:
+                    pass
+        self._wpk_cache.clear()
+
+    # ------------------------------------------------------------------
+    # Delegated IDX parsing
+    # ------------------------------------------------------------------
+    def _read_idx_header(self, file) -> None:
+        read_idx_header(self, file)
+
+    def _read_idx_indices(self, file) -> None:
+        read_idx_indices(self, file)
+
+    def _log_idx_split_summary(self) -> None:
+        log_idx_split_summary(self)
+
+    # ------------------------------------------------------------------
+    # Delegated path + slot_file helpers
+    # ------------------------------------------------------------------
+    def _iter_wpk_path_candidates(self, pkg_id: int):
+        yield from self._path_resolver.iter_wpk_path_candidates(pkg_id)
+
+    def _find_wpk_path(self, pkg_id: int) -> str:
+        return self._path_resolver.find_wpk_path(pkg_id)
+
+    def _is_slot_file_pkg(self, pkg_id: int) -> bool:
+        return self._path_resolver.is_slot_file_pkg(pkg_id)
+
+    def _get_slot_file_dir(self):
+        return self._path_resolver.get_slot_file_dir()
+
+    def _read_slot_file_data(self, entry: NPKEntry) -> bytes | None:
+        return self._slot_file_resolver.read_slot_file_data(entry)
+
+    def _get_wpk_handle(self, pkg_id: int) -> BinaryIO | None:
+        return self._path_resolver.get_wpk_handle(pkg_id)
+
+    # ------------------------------------------------------------------
+    # Delegated payload processing
+    # ------------------------------------------------------------------
+    def _maybe_unpack_dtsz(self, data: bytes, *, context: str) -> tuple[bytes, bool]:
+        return self._payload_processor.maybe_unpack_dtsz(data, context=context)
+
+    def _maybe_strip_enon_header(self, data: bytes, *, context: str) -> tuple[bytes, bool]:
+        return self._payload_processor.maybe_strip_enon_header(data, context=context)
+
+    def _unwrap_nested_payloads(self, entry: NPKEntry, *, context: str) -> None:
+        self._payload_processor.unwrap_nested_payloads(entry, context=context)
+
+    def _maybe_unpack_cobl(self, data: bytes, *, context: str) -> tuple[bytes, bool]:
+        return self._payload_processor.maybe_unpack_cobl(data, context=context)
+
+    def _decode_cobl_concat(self, data: bytes, *, context: str) -> bytes:
+        return self._payload_processor.decode_cobl_concat(data, context=context)
+
+    def _decode_cobl_block(self, data: bytes, *, context: str) -> bytes:
+        return self._payload_processor.decode_cobl_block(data, context=context)
+
+    def _deobfuscate_cobl_probe_region(self, data: bytes) -> tuple[bytes, int]:
+        return self._payload_processor.deobfuscate_cobl_probe_region(data)
+
+    def _score_slot_stage1_candidate(self, data: bytes) -> tuple[int, str]:
+        return self._payload_processor.score_slot_stage1_candidate(data)
+
+    def _decode_slot_payload_auto(self, payload: bytes, *, context: str) -> tuple[bytes, bool, int | None, bool]:
+        return self._payload_processor.decode_slot_payload_auto(payload, context=context)
+
+    # ------------------------------------------------------------------
+    # Delegated standalone WPK parsing
+    # ------------------------------------------------------------------
+    def _read_wpk_header(self, file) -> None:
+        read_wpk_header(self, file)
+
+    def _scan_wpk_indices(self, file) -> None:
+        scan_wpk_indices(self, file)
+
+    def _build_index_from_embedded_header(self, data: bytes, off: int, next_off: int, ordinal: int) -> NPKIndex:
+        return build_index_from_embedded_header(data, off, next_off, ordinal)
+
+    # ------------------------------------------------------------------
+    # Unified entry API
+    # ------------------------------------------------------------------
+    def is_entry_loaded(self, index: int) -> bool:
+        return index in self.entries
+
+    def read_entry(self, index: int) -> NPKEntry:
+        if index in self.entries:
+            return self.entries[index]
+
+        entry = NPKEntry()
+        if not 0 <= index < len(self.indices):
+            get_logger().critical("Entry index out of range: %d", index)
+            entry.data_flags |= NPKEntryDataFlags.ERROR
+            return entry
+
+        idx = self.indices[index]
+        for attr in vars(idx):
+            setattr(entry, attr, getattr(idx, attr))
+
+        entry.is_slot_file = False
+        entry.source_mode = self.mode
+        entry.stage1_decoded = False
+        entry.stage1_tag = None
+        try:
+            self._load_entry_data(entry)
+        except Exception as exc:
+            get_logger().exception("Failed to load IDX/WPK entry %d: %s", index, exc)
+            entry.data = b""
+            entry.extension = "bin"
+            entry.category = get_file_category(entry.extension)
+            entry.data_flags |= NPKEntryDataFlags.ERROR
+            self.entries[index] = entry
+            return entry
+
+        if "." not in entry.filename:
+            entry.filename = f"{entry.filename}.{entry.extension}"
+
+        self.entries[index] = entry
+        return entry
+
+    def _load_entry_data(self, entry: NPKEntry):
+        pkg_id = getattr(entry, "pkg_id", None)
+        if pkg_id is None:
+            raise ValueError("Entry missing pkg_id")
+
+        raw_data: bytes
+        payload: bytes
+
+        if self.mode == "idx" and self._is_slot_file_pkg(pkg_id):
+            raw_data = self._read_slot_file_data(entry)
+            if raw_data is None:
+                raise FileNotFoundError(
+                    f"Missing slot_file for pkg_id={pkg_id} in {self._get_slot_file_dir()}"
+                )
+            entry.is_slot_file = True
+            entry.source_mode = "slot_file"
+            entry.file_length = len(raw_data)
+            entry.file_original_length = len(raw_data)
+            hdr_size = getattr(entry, "hdr_size", 0)
+            payload_size = getattr(entry, "payload_size", 0)
+            if raw_data[:4] == b"1DPW":
+                payload = raw_data[hdr_size:hdr_size + payload_size] if payload_size > 0 else raw_data[hdr_size:]
+            else:
+                payload = raw_data
+        else:
+            handle = self._get_wpk_handle(pkg_id)
+            if handle is None:
+                raise FileNotFoundError(f"Missing WPK for pkg_id={pkg_id}")
+
+            hdr_size = getattr(entry, "hdr_size", 0)
+            payload_size = getattr(entry, "payload_size", 0)
+            total_size = entry.file_length if entry.file_length > 0 else hdr_size + payload_size
+
+            handle.seek(entry.file_offset)
+            raw_data = handle.read(total_size)
+            if len(raw_data) != total_size:
+                raise EOFError(f"Failed to read entry data: expected {total_size}, got {len(raw_data)}")
+
+            if hdr_size > 0 and hdr_size <= len(raw_data):
+                payload = raw_data[hdr_size:hdr_size + payload_size] if payload_size > 0 else raw_data[hdr_size:]
+            else:
+                payload = raw_data
+
+        entry.raw_data = raw_data
+        entry.payload_data = payload
+
+        stage1_context = f"{entry.filename} pkg={pkg_id} source={entry.source_mode}"
+        used_skip_header_decode = False
+        if entry.is_slot_file:
+            processed, decoded, tag, used_skip_header_decode = self._decode_slot_payload_auto(
+                payload,
+                context=stage1_context,
+            )
+        else:
+            processed, decoded, tag = try_decode_payload_stage1(
+                payload,
+                context=stage1_context,
+                skip_header_decode=False,
+            )
+
+        entry.stage1_decoded = decoded
+        entry.stage1_tag = tag
+        entry.stage1_skip_header_decode = used_skip_header_decode
+
+        if decoded:
+            entry.data = processed
+            get_logger().debug(
+                "WPD1 stage1 decoded: %s pkg=%s source=%s slot=%s skip_header_decode=%s tag=0x%04X in=%d out=%d",
+                entry.filename,
+                pkg_id,
+                entry.source_mode,
+                entry.is_slot_file,
+                used_skip_header_decode,
+                tag if tag is not None else 0,
+                len(payload),
+                len(processed),
+            )
+        else:
+            entry.data = payload
+            get_logger().debug(
+                "WPD1 stage1 fallback raw: %s pkg=%s source=%s len=%d",
+                entry.filename,
+                pkg_id,
+                entry.source_mode,
+                len(payload),
+            )
+
+        entry.none_header_stripped = False
+        entry.dtsz_unpacked = False
+        entry.enon_header_stripped = False
+        entry.cobl_unpacked = False
+        entry.unwrap_layers = []
+        self._unwrap_nested_payloads(
+            entry,
+            context=f"{entry.filename} pkg={pkg_id} source={entry.source_mode}",
+        )
+
+        entry.file_length = len(entry.data)
+        entry.file_original_length = len(entry.data)
+
+        if not is_binary(entry.data):
+            entry.data_flags |= NPKEntryDataFlags.TEXT
+
+        entry.source_extension = get_ext(entry.data, entry.data_flags)
+        entry.extension = get_ext(entry.data, entry.data_flags)
+        entry.category = get_file_category(entry.extension)
+
+        get_logger().debug(
+            "Loaded IDX/WPK entry: %s pkg=%s off=0x%X len=%d ext=%s mode=%s source=%s slot=%s stage1=%s unwrap=%s",
+            entry.filename,
+            pkg_id,
+            entry.file_offset,
+            len(entry.data),
+            entry.extension,
+            self.mode,
+            entry.source_mode,
+            entry.is_slot_file,
+            entry.stage1_decoded,
+            ",".join(entry.unwrap_layers) if entry.unwrap_layers else "-",
+        )

--- a/gui/models/npk_file_model.py
+++ b/gui/models/npk_file_model.py
@@ -1,7 +1,7 @@
 """A custom model for displaying NPK files in a QListView."""
 
 from typing import Any, cast
-from PySide6 import QtCore, QtWidgets
+from PySide6 import QtCore, QtGui, QtWidgets
 
 from core.config import Config
 from core.npk.class_types import NPKEntryDataFlags
@@ -62,6 +62,11 @@ class NPKFileModel(QtCore.QAbstractListModel):
                 return self._encrypted_icon
 
             return self._file_icon
+        if role == QtCore.Qt.ItemDataRole.ForegroundRole:
+            if self._npk_file.is_entry_loaded(index.row()):
+                entry = self._npk_file.read_entry(index.row())
+                if getattr(entry, "is_slot_file", False):
+                    return QtGui.QBrush(QtGui.QColor(0, 170, 0))
         if role == QtCore.Qt.ItemDataRole.UserRole:
             return self._npk_file.indices[index.row()]
         return None

--- a/gui/npk_entry_filter.py
+++ b/gui/npk_entry_filter.py
@@ -16,6 +16,7 @@ class NPKEntryFilter:
         self.filter_type: NPKEntryFileCategories | None = None
         self.include_text = True
         self.include_binary = True
+        self.include_slot = True
 
         self.mesh_biped_head = False
 
@@ -37,18 +38,24 @@ class NPKEntryFilter:
         for row in range(model.rowCount()):
             npk_entry = npk_file.read_entry(row)
             filename_lower = model.get_filename(model.index(row)).lower()
+            is_slot_file = getattr(npk_entry, "is_slot_file", False)
 
-            if self.include_text == self.include_binary == False:
-                # If both are unchecked, hide all
-                self._list_view.setRowHidden(row, True)
-                continue
-
-            if self.include_text != self.include_binary:
-                # If only one is checked, hide the other
-                if self.include_text and not npk_entry.data_flags & NPKEntryDataFlags.TEXT or \
-                     (self.include_binary and npk_entry.data_flags & NPKEntryDataFlags.TEXT):
+            if is_slot_file:
+                if not self.include_slot:
                     self._list_view.setRowHidden(row, True)
                     continue
+            else:
+                if self.include_text == self.include_binary == False:
+                    # If both are unchecked, hide all non-slot files
+                    self._list_view.setRowHidden(row, True)
+                    continue
+
+                if self.include_text != self.include_binary:
+                    # If only one is checked, hide the other
+                    is_text_file = bool(npk_entry.data_flags & NPKEntryDataFlags.TEXT)
+                    if (self.include_text and not is_text_file) or (self.include_binary and is_text_file):
+                        self._list_view.setRowHidden(row, True)
+                        continue
 
             # Text filter - quick reject
             if self.filter_string and self.filter_string not in filename_lower:

--- a/gui/widgets/npk_file_list.py
+++ b/gui/widgets/npk_file_list.py
@@ -150,7 +150,11 @@ class NPKFileList(QtWidgets.QListView):
 
         # Add extract option for any selection
         extract = menu.addAction("Extract")
-        extract.triggered.connect(lambda: self.extract_entries(indexes))
+        extract.triggered.connect(lambda: self.extract_entries(indexes, decoded=True))
+
+        if self._selection_has_decoded_entries(indexes):
+            extract_raw = menu.addAction("Extract Raw")
+            extract_raw.triggered.connect(lambda: self.extract_entries(indexes, decoded=False))
 
         menu.addSeparator()
         for viewer in ALL_VIEWERS:
@@ -182,7 +186,17 @@ class NPKFileList(QtWidgets.QListView):
             entry = npk_file.read_entry(row)
             self.open_entry_with.emit(row, entry, viewer, i)
 
-    def extract_entries(self, indexes: list[QtCore.QModelIndex]):
+    def _selection_has_decoded_entries(self, indexes: list[QtCore.QModelIndex]) -> bool:
+        npk_file = get_npk_file()
+        if npk_file is None:
+            return False
+        for index in indexes:
+            entry = npk_file.read_entry(index.row())
+            if getattr(entry, "has_decoded_view", False):
+                return True
+        return False
+
+    def extract_entries(self, indexes: list[QtCore.QModelIndex], decoded: bool = True):
         """
         Extract selected entries from the NPK file.
         
@@ -196,10 +210,10 @@ class NPKFileList(QtWidgets.QListView):
             # For single file, show file save dialog with filename pre-filled
             index = indexes[0]
             row_index = index.row()
-            filename = self.model().get_filename(index)
 
-            # Get the entry data
+            # Get the entry data first so the detected extension is reflected in the filename.
             entry = npk_file.read_entry(row_index)
+            filename = os.path.basename(entry.get_export_filename(decoded=decoded)) or self.model().get_filename(index)
 
             # Show save file dialog
             file_path, _ = QtWidgets.QFileDialog.getSaveFileName(
@@ -212,7 +226,7 @@ class NPKFileList(QtWidgets.QListView):
             if file_path:
                 try:
                     with open(file_path, 'wb') as f:
-                        f.write(entry.data)
+                        f.write(entry.get_export_data(decoded=decoded))
                     QtWidgets.QMessageBox.information(
                         self,
                         "Success", 
@@ -240,7 +254,10 @@ class NPKFileList(QtWidgets.QListView):
 
                     for index in indexes:
                         row_index = index.row()
-                        filename = self.model().get_filename(index)
+
+                        # Get the entry data first so the detected extension is reflected in the filename.
+                        entry = npk_file.read_entry(row_index)
+                        filename = os.path.basename(entry.get_export_filename(decoded=decoded)) or self.model().get_filename(index)
 
                         # Create safe filename
                         safe_filename = os.path.basename(filename)
@@ -249,12 +266,9 @@ class NPKFileList(QtWidgets.QListView):
 
                         file_path = os.path.join(dir_path, safe_filename)
 
-                        # Get the entry data
-                        entry = npk_file.read_entry(row_index)
-
                         try:
                             with open(file_path, 'wb') as f:
-                                f.write(entry.data)
+                                f.write(entry.get_export_data(decoded=decoded))
                             success_count += 1
                         except Exception:
                             fail_count += 1

--- a/gui/windows/main_window.py
+++ b/gui/windows/main_window.py
@@ -10,6 +10,7 @@ from core.config import Config
 from core.logger import get_logger
 from core.npk.enums import NPKEntryFileCategories
 from core.npk.npk_file import NPKFile
+from core.wpk.wpk_file import IDXWPKFile
 from core.npk.class_types import NPKEntry, NPKEntryDataFlags, NPKReadOptions
 from gui.config_manager import ConfigManager
 from gui.models.npk_file_model import NPKFileModel
@@ -209,7 +210,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 "Open File",
                 self
             )
-            open_file.setStatusTip("Open a NPK file.")
+            open_file.setStatusTip("Open a supported archive file.")
             open_file.setShortcut("Ctrl+O")
             menu.addAction(open_file)
 
@@ -223,9 +224,9 @@ class MainWindow(QtWidgets.QMainWindow):
                     return
                 file_path, _ = QtWidgets.QFileDialog.getOpenFileName(
                     self,
-                    "Open NPK File",
+                    "Open Archive File",
                     "",
-                    "NPK Files (*.npk);;All Files (*)"
+                    "Supported Files (*.npk *.expk *.idx *.wpk);;NPK Files (*.npk *.expk);;IDX Files (*.idx);;WPK Files (*.wpk);;All Files (*)"
                 )
                 if file_path:
                     self.load_npk(file_path)
@@ -420,21 +421,27 @@ class MainWindow(QtWidgets.QMainWindow):
             # No read options set, use default
             read_options = NPKReadOptions()
 
-        npk_file = NPKFile(path, read_options)
+        ext = os.path.splitext(path)[1].lower()
+        if ext in (".npk", ".expk"):
+            archive_file = NPKFile(path, read_options)
+        elif ext in (".idx", ".wpk"):
+            archive_file = IDXWPKFile(path, read_options)
+        else:
+            raise ValueError(f"Unsupported archive type: {path}")
 
-        self.app.setProperty("npk_file", npk_file)
+        self.app.setProperty("npk_file", archive_file)
 
         self.list_widget.refresh_npk_file()
 
         self.progress_bar.setFormat("Loading entries... (%v/%m)")
-        self.progress_bar.setRange(0, npk_file.file_count)
+        self.progress_bar.setRange(0, archive_file.file_count)
         self.progress_bar.setValue(0)
 
         def _load_entries():
-            for i in range(npk_file.file_count):
+            for i in range(archive_file.file_count):
                 if self._loading_cancelled:
                     break
-                npk_file.read_entry(i)
+                archive_file.read_entry(i)
                 self.update_model_signal.emit(i)
                 self.update_progress_signal.emit(i + 1)
             self.loading_complete_signal.emit()

--- a/gui/windows/main_window.py
+++ b/gui/windows/main_window.py
@@ -119,6 +119,14 @@ class MainWindow(QtWidgets.QMainWindow):
         self.filter_text_filter.toggled.connect(filter_text_filter_changed)
         self.filter_checkbox_section.addWidget(self.filter_text_filter, 0, 1)
 
+        self.filter_slot_filter = QtWidgets.QCheckBox("Slot Files")
+        self.filter_slot_filter.setChecked(True)
+        def filter_slot_filter_changed(checked: bool):
+            self.filter.include_slot = checked
+            self.filter.apply_filter()
+        self.filter_slot_filter.toggled.connect(filter_slot_filter_changed)
+        self.filter_checkbox_section.addWidget(self.filter_slot_filter, 0, 2)
+
         self.filter_section.addLayout(self.filter_checkbox_section)
 
         self.entry_category_filter_combobox = QtWidgets.QComboBox()


### PR DESCRIPTION
Hi, I went through my fork and split the changes into a small series of focused commits so the differences are easier to review.

I also removed my personal/project-specific renaming, branding, and copyright-related changes from these commits. What remains here are only the functional changes that may be useful upstream.

This branch currently includes the following commits:

1. **feat: add IDX/WPK archive reader support**
   Adds support for reading `.idx` / `.wpk` archives, including split package resolution, `slot_file` payload handling, and the basic IDX/WPK loading path in the main window.

2. **feat: add slot file highlighting and filtering**
   Highlights `slot_file` entries in the file list and adds a dedicated filter toggle so they can be inspected separately from normal text/binary entries.

3. **feat: add format processor pipeline with built-in BXML decoding**
   Introduces a small post-processing pipeline for decoded payloads and adds a built-in BXML decoder. This keeps both original payload metadata and decoded content available for later use.

4. **feat: add raw export support for processed entries**
   Adds export helpers so processed entries can be exported either as decoded output or as raw source data, with the file list UI exposing the corresponding extraction actions.

5. **fix: improve texture detection and DDS/ASTC decoding**
   Improves texture-related handling by adding PSD detection, DDS DX10 fallback handling for unsupported BGRA/BGRX cases, ASTC payload validation, and corrected ASTC 6x6 mapping.

6. **fix: unwrap nested payload wrappers in NPK entries**
   Improves NPK entry unpacking by recursively unwrapping several common nested wrapper formats (`NONE`, custom LZ4-like wrappers, `ROTOR`, `NXS3`) and also makes NXFN filename handling safer.

I intentionally did not include personal renaming/branding changes, packaging/UI branding updates, or the larger viewer refactor from my fork.
