### PR TITLE
Fix duplicate WPK loading and first-row highlight

### DIFF
--- a/core/wpk/wpk_file.py
+++ b/core/wpk/wpk_file.py
@@ -247,9 +247,6 @@ class IDXWPKFile:
         for attr in vars(idx):
             setattr(entry, attr, getattr(idx, attr))
 
-        # Load the actual data
-        self._load_entry_data(entry)
-
         try:
             self._load_entry_data(entry)
         except Exception as exc:
@@ -266,6 +263,7 @@ class IDXWPKFile:
 
         entry.state = State.CACHED
         self.entries[index] = entry
+        return entry
 
     def _load_entry_data(self, entry: NPKEntry):
         pkg_id = getattr(entry, "pkg_id", None)

--- a/gui/widgets/npk_file_list.py
+++ b/gui/widgets/npk_file_list.py
@@ -119,7 +119,7 @@ class NPKFileList(QtWidgets.QListView):
         entry = npk_file.find_entry_by_id(row_index)
         entry.state = State.PRIMARY_LOAD
 
-        if not previous.row() == 0:
+        if not previous.row() == -1:
             npk_file.find_entry_by_id(previous.row()).state = State.CACHED
 
         self.preview_entry.emit(row_index, entry)


### PR DESCRIPTION
This PR fixes two small issues:

- remove the duplicate `_load_entry_data()` call in `IDXWPKFile.load_entry()`
- fix the list selection logic so row 0 does not stay highlighted