### PR TITLE
fix: correct BXML tree reconstruction for scene files

### DIFF
--- a/core/formats/bxml.py
+++ b/core/formats/bxml.py
@@ -99,7 +99,10 @@ def parse_bxml_bytes(data: bytes) -> str:
     if len(total_size_raw) != 8:
         raise ValueError("Truncated BXML header.")
     _total_size = struct.unpack("<Q", total_size_raw)[0]
-    payload_start = buf.tell()
+    ## 校验total_size
+    # if _total_size != len(data):
+    #     raise ValueError(f"Header size mismatch: {_total_size} != {len(data)}")
+    # payload_start = buf.tell()
 
     tag_names = _read_string_pool(buf)
     attr_names = _read_string_pool(buf)
@@ -113,11 +116,19 @@ def parse_bxml_bytes(data: bytes) -> str:
     nodes_info: list[dict[str, object]] = []
     for i in range(node_count):
         tag_idx = _read_leb128(buf)
-        child_count = _read_leb128(buf)
+        relation_count = _read_leb128(buf)
         tag_name = tag_names[tag_idx] if 0 <= tag_idx < len(tag_names) else f"node_{i}"
-        nodes_info.append({"tag": tag_name, "child_count": child_count})
+        nodes_info.append({"tag": tag_name, "relation_count": relation_count})
 
-    buf.seek(payload_start + attr_data_offset)
+    ## 校验元数据区和数据区切分点
+    # meta_end = buf.tell()
+    # expected_data_start = payload_start + attr_data_offset
+    # if meta_end != expected_data_start:
+    #     raise ValueError(
+    #         f"Metadata/data split mismatch: meta_end={meta_end}, "
+    #         f"expected_data_start={expected_data_start}"
+    #     )
+    # buf.seek(payload_start + attr_data_offset)
 
     for i in range(node_count):
         attr_count = _read_leb128(buf)
@@ -142,28 +153,44 @@ def parse_bxml_bytes(data: bytes) -> str:
         node_type_tag = node_type_tag_raw[0]
         nodes_info[i]["value"] = _read_bxml_value(buf, node_type_tag)
 
-    current_node_idx = 0
-
-    def build_xml_tree():
-        nonlocal current_node_idx
-        if current_node_idx >= len(nodes_info):
-            return None
-
-        info = nodes_info[current_node_idx]
-        current_node_idx += 1
-
+    # 先创建所有节点对象
+    elements: list[ET.Element] = []
+    for info in nodes_info:
         elem = ET.Element(str(info["tag"]), info.get("attrs", {}))
         value = info.get("value")
-        if value:
+        if value not in ("", None):
             elem.text = str(value)
+        elements.append(elem)
 
-        for _ in range(int(info.get("child_count", 0))):
-            child = build_xml_tree()
-            if child is not None:
-                elem.append(child)
-        return elem
+    # 按“连续子节点区间”分配孩子
+    # 假设节点 0 是根，后续节点按层次/顺序排列
+    cursor = 1
+    for i in range(node_count):
+        child_count = int(nodes_info[i].get("relation_count", 0))
+        if child_count < 0:
+            raise ValueError(f"Negative child_count at node {i}")
 
-    root = build_xml_tree()
+        if cursor + child_count > node_count:
+            raise ValueError(
+                f"Invalid child_count at node {i}: {child_count}, "
+                f"cursor={cursor}, node_count={node_count}"
+            )
+
+        nodes_info[i]["child_ids"] = list(range(cursor, cursor + child_count))
+        cursor += child_count
+
+    # 连通树应满足：总孩子数 = node_count - 1
+    if cursor != node_count:
+        raise ValueError(
+            f"Tree layout mismatch: cursor={cursor}, expected={node_count}"
+        )
+
+    # 真正挂接子节点
+    for i, info in enumerate(nodes_info):
+        for child_id in info.get("child_ids", []):
+            elements[i].append(elements[child_id])
+
+    root = elements[0] if elements else None
     if root is None:
         raise ValueError("BXML contains no nodes.")
 


### PR DESCRIPTION
The old parser assumed the node relation field could be consumed through
recursive preorder traversal. Reverse-engineering indicates the file is
better modeled as:

- string pools
- node metadata section
- node data section
- node relationships reconstructed from metadata counts

Using recursive consumption on the raw node stream leads to invalid tree
shape on real scene files.